### PR TITLE
Add FAQ item for troubleshooting potential rclone error

### DIFF
--- a/utilities/durbinlab/README.md
+++ b/utilities/durbinlab/README.md
@@ -21,6 +21,6 @@ We suggest using [`rclone`](https://rclone.org) to assist with data uploads to t
 ## Frequently Asked Questions (FAQ)
 
 - __Question__: What should I do if I see the error: `"Error 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled."`?
-- __Answer__: Try using the following:
+- __Answer__: Try using one of the following options (only one is needed):
   - Add an environment variable like the following (command may vary based on operating system): `export RCLONE_GCS_BUCKET_POLICY_ONLY=true`
   - Use an additional command-line flag `rclone --gcs-bucket-policy-only ...<the rest of your command goes here>...`

--- a/utilities/durbinlab/README.md
+++ b/utilities/durbinlab/README.md
@@ -22,5 +22,5 @@ We suggest using [`rclone`](https://rclone.org) to assist with data uploads to t
 
 - __Question__: What should I do if I see the error: `"Error 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled."`?
 - __Answer__: Try using the following:
-  - Add an environment variable like the following: `RCLONE_GCS_BUCKET_POLICY_ONLY=true`
+  - Add an environment variable like the following (command may vary based on operating system): `export RCLONE_GCS_BUCKET_POLICY_ONLY=true`
   - Use an additional command-line flag `rclone --gcs-bucket-policy-only ...<the rest of your command goes here>...`

--- a/utilities/durbinlab/README.md
+++ b/utilities/durbinlab/README.md
@@ -17,3 +17,10 @@ We suggest using [`rclone`](https://rclone.org) to assist with data uploads to t
 
    - Please note: many rclone commands are recursive __by default__ with options to disable.
    - An example with the sync command: `rclone sync <data source>  <configured_name>:waylab-durbinlab-bucket`
+
+## Frequently Asked Questions (FAQ)
+
+- __Question__: What should I do if I see the error: `"Error 400: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled."`?
+- __Answer__: Try using the following:
+  - Add an environment variable like the following: `RCLONE_GCS_BUCKET_POLICY_ONLY=true`
+  - Use an additional command-line flag `rclone --gcs-bucket-policy-only ...<the rest of your command goes here>...`


### PR DESCRIPTION
This PR adds documentation to help troubleshoot potential scenarios where data upload is prevented based on the bucket settings and how rclone operates.